### PR TITLE
Make types serde serialisable if serde feature used

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         rust-version: ["stable"]
         mpi: ['mpich', 'openmpi']
-        feature-flags: ['--features "strict"', '--features "mpi,strict"']
+        feature-flags: ['--features "strict"', '--features "mpi,strict"', '--features "serde,strict"']
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         rust-version: ["stable"]
         mpi: ['mpich', 'openmpi']
-        feature-flags: ['--features "strict"', '--features "mpi,strict"', '--features "serde,strict"']
+        feature-flags: ['--features "strict"', '--features "mpi,serde,strict"']
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        feature-flags: ['--features "mpi,strict"', '--features "strict"', '--features "serde,strict"' '']
+        feature-flags: ['--features "mpi,strict"', '--features "strict"', '--features "serde,strict"', '']
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        feature-flags: ['--features "mpi,strict"', '--features "strict"', '--features "serde,strict"', '']
+        feature-flags: ['--features "mpi,serde,strict"', '--features "strict"']
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        feature-flags: ['--features "mpi,strict"', '--features "strict"', '']
+        feature-flags: ['--features "mpi,strict"', '--features "strict"', '--features "serde,strict"' '']
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [features]
 mpi = ["dep:mpi"]
+serde = ["dep:serde"]
 strict = []
 
 [package]
@@ -32,6 +33,7 @@ log = "0.4"
 rayon = "1.9"
 rand = "0.8.5"
 rlst = "0.2.0"
+serde = { version = "1", features = ["derive"], optional = true }
 thiserror="1.*"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,34 +21,19 @@ name = "ndelement"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-approx = "0.5"
-cauchy = "0.4.*"
 itertools = "0.13.*"
 mpi = { version = "0.8.*", optional = true }
 num = "0.4"
-paste = "1.*"
-lazy_static = "1.4"
-libc = "0.2"
-log = "0.4"
-rayon = "1.9"
-rand = "0.8.5"
 rlst = "0.2.0"
 serde = { version = "1", features = ["derive"], optional = true }
-thiserror="1.*"
 
 [dev-dependencies]
 bempp = "0.1.0"
+paste = "1.*"
+approx = "0.5"
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [lints.clippy]
 wildcard_imports = "forbid"
-
-[target.aarch64-apple-darwin.dev-dependencies]
-blas-src = { version = "0.10", features = ["accelerate"]}
-lapack-src = { version = "0.10", features = ["accelerate"]}
-
-[target.x86_64-unknown-linux-gnu.dev-dependencies]
-blas-src = { version = "0.10", features = ["blis"]}
-lapack-src = { version = "0.10", features = ["netlib"]}

--- a/examples/element_family.rs
+++ b/examples/element_family.rs
@@ -2,9 +2,6 @@ use ndelement::ciarlet::LagrangeElementFamily;
 use ndelement::traits::{ElementFamily, FiniteElement};
 use ndelement::types::{Continuity, ReferenceCellType};
 
-extern crate blas_src;
-extern crate lapack_src;
-
 fn main() {
     // Create the degree 2 Lagrange element family. A family is a set of finite elements with the
     // same family type, degree, and continuity across a set of cells

--- a/examples/lagrange_element.rs
+++ b/examples/lagrange_element.rs
@@ -5,9 +5,6 @@ use ndelement::{
 };
 use rlst::{rlst_dynamic_array2, rlst_dynamic_array4, RawAccess};
 
-extern crate blas_src;
-extern crate lapack_src;
-
 fn main() {
     // Create a P2 element on a triangle
     let element = lagrange::create::<f64>(ReferenceCellType::Triangle, 2, Continuity::Standard);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! n-dimensional grid
-#![cfg_attr(feature = "strict", deny(warnings))]
+#![cfg_attr(feature = "strict", deny(warnings), deny(unused_crate_dependencies))]
 #![warn(missing_docs)]
 
 pub mod ciarlet;
@@ -7,9 +7,3 @@ pub mod polynomials;
 pub mod reference_cell;
 pub mod traits;
 pub mod types;
-
-#[cfg(test)]
-mod test {
-    extern crate blas_src;
-    extern crate lapack_src;
-}

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@
 use mpi::traits::Equivalence;
 
 /// Continuity type
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[repr(u8)]
 pub enum Continuity {
@@ -17,6 +18,7 @@ pub enum Continuity {
 }
 
 /// The map type used by an element
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[repr(u8)]
 pub enum MapType {
@@ -35,6 +37,7 @@ pub enum MapType {
 }
 
 /// The type of a reference cell
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[repr(u8)]
 pub enum ReferenceCellType {


### PR DESCRIPTION
Added a "serde" feature. If this is enabled, enums in types.rs will be serde serializable. This allows them to (for example) be used with [RON](https://github.com/ron-rs/ron).